### PR TITLE
Simplified AstroStackWindow constructor and more version bumping.

### DIFF
--- a/src/main/java/Astronomy_Listener.java
+++ b/src/main/java/Astronomy_Listener.java
@@ -22,7 +22,7 @@ public class Astronomy_Listener implements PlugIn, ImageListener {
     public static final boolean NORESIZE = false;
 
     public void run(String arg) {
-        if (IJ.versionLessThan("1.35l")) return;
+        if (IJ.versionLessThan("1.52i")) return;
         ImagePlus.addImageListener(this);
     }
 
@@ -40,7 +40,7 @@ public class Astronomy_Listener implements PlugIn, ImageListener {
             if (!(openFrame instanceof astroj.AstroStackWindow))//(mainComponentClass.getName() != "astroj.AstroStackWindow")
             {
                 AstroCanvas ac = new AstroCanvas(imp);
-                AstroStackWindow astroWindow = new AstroStackWindow(imp, ac, NEW, RESIZE);
+                AstroStackWindow astroWindow = new AstroStackWindow(imp, ac);
             }
         }
 

--- a/src/main/java/Astronomy_Tool.java
+++ b/src/main/java/Astronomy_Tool.java
@@ -54,7 +54,7 @@ public class Astronomy_Tool implements PlugIn //, ImageListener
             else
                 resizeNoResize = NORESIZE;
             AstroCanvas ac = new AstroCanvas(imp);
-            AstroStackWindow astroWindow = new AstroStackWindow(imp, ac, NEW, resizeNoResize);
+            AstroStackWindow astroWindow = new AstroStackWindow(imp, ac, resizeNoResize);
         }
     }
 }

--- a/src/main/java/Set_Telescope.java
+++ b/src/main/java/Set_Telescope.java
@@ -31,7 +31,7 @@ public class Set_Telescope implements PlugIn {
      * Standard ImageJ PluginFilter setup routine which retrieves, displays, and re-stores telescope information.
      */
     public void run(String arg) {
-        if (IJ.versionLessThan("1.311")) return;
+        if (IJ.versionLessThan("1.52i")) return;
 
         String[] tel;
 

--- a/src/main/java/astroj/AstroStackWindow.java
+++ b/src/main/java/astroj/AstroStackWindow.java
@@ -435,7 +435,13 @@ public class AstroStackWindow extends StackWindow implements LayoutManager, Acti
         }
     };
 
-    public AstroStackWindow(ImagePlus imp, AstroCanvas ac, boolean refresh, boolean resize) {
+    // This constructor is simply a convenience without the resize argument.
+    // way AstroStackWindow is constructed in Astronomy_Listener.
+    public AstroStackWindow(ImagePlus imp, AstroCanvas ac) {
+        this(imp, ac, RESIZE);
+    }
+
+    public AstroStackWindow(ImagePlus imp, AstroCanvas ac, boolean resize) {
 
         super(imp, ac);
         Locale.setDefault(IJU.locale);

--- a/src/main/java/astroj/MeasurementTable.java
+++ b/src/main/java/astroj/MeasurementTable.java
@@ -561,7 +561,7 @@ public class MeasurementTable extends ResultsTable {
 
         // FIND MEASUREMENT TABLES ASSOCIATED WITH IMAGES
 
-        if (IJ.versionLessThan("1.40")) {
+        if (IJ.versionLessThan("1.52i")) {
             Frame std = WindowManager.getFrame("Results");
             if (std != null)
                 frames.addElement("Results");


### PR DESCRIPTION
The simplified constructor could be very useful if we abandon the notifyListeners() approach to swapping in an AstroStackWindow for a regular StackWindow. In any case, it is a slight tidying.